### PR TITLE
Fix typo in `navigate` error

### DIFF
--- a/src/client/router/index.node.ts
+++ b/src/client/router/index.node.ts
@@ -7,7 +7,7 @@ assert(isNodejs())
 function navigate(): never {
   assertUsage(
     false,
-    '[`navigate(url)`] The `navigate(ur)` function is only callable in the browser but you are calling it in Node.js.'
+    '[`navigate(url)`] The `navigate(url)` function is only callable in the browser but you are calling it in Node.js.'
   )
 }
 


### PR DESCRIPTION
Just a small thing I noticed!

Also note the Readme appears to be incorrect in this area, it states `In Node.js, navigate() is a no-op.`, which is not correct.