### PR TITLE
indicate Node 15 requirement in contribution docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,9 @@
 - [Run Test Suite](#run-test-suite)
 
 
+## Environment Requirements
+- Node 15.*.*
+
 ## Modify Example
 
 To run an example:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 
 ## Environment Requirements
-- Node 15.*.*
+- Node.js 15.*.*
 
 ## Modify Example
 


### PR DESCRIPTION
The project uses Node workspaces which were added in Node 15. I had my default set to Node 14 and the setup instructions didn't work. Probably best to indicate this requirement to potential contributors.