### PR TITLE
fix: allow fetching new page props before url change

### DIFF
--- a/src/client/navigationState.client.ts
+++ b/src/client/navigationState.client.ts
@@ -10,6 +10,9 @@ export const navigationState = {
   get isFirstNavigation() {
     return !navigationChanged && this.checkIfOriginalUrl(this.urlNow);
   },
+  checkIfCurrentUrl(url : string) {
+    return url === this.urlNow;
+  },
   checkIfOriginalUrl(url : string) {
     return url === this.urlOriginal;
   },

--- a/src/client/navigationState.client.ts
+++ b/src/client/navigationState.client.ts
@@ -1,14 +1,13 @@
 import { getUrlPathname } from './getUrl.client'
 
-let urlOriginal = getUrlPathname()
-let navigationChanged = false
+let urlOriginal = getUrlPathname();
 
 export const navigationState = {
-  markNavigationChange() {
-    navigationChanged = true
-  },
   get isFirstNavigation() {
-    return !navigationChanged && this.urlNow === this.urlOriginal
+    return this.checkIfOriginalUrl(this.urlNow);
+  },
+  checkIfOriginalUrl(url : string) {
+    return url === this.urlOriginal;
   },
   get urlOriginal() {
     return urlOriginal

--- a/src/client/navigationState.client.ts
+++ b/src/client/navigationState.client.ts
@@ -1,10 +1,14 @@
 import { getUrlPathname } from './getUrl.client'
 
 let urlOriginal = getUrlPathname();
+let navigationChanged = false
 
 export const navigationState = {
+  markNavigationChange() {
+    navigationChanged = true
+  },
   get isFirstNavigation() {
-    return this.checkIfOriginalUrl(this.urlNow);
+    return !navigationChanged && this.checkIfOriginalUrl(this.urlNow);
   },
   checkIfOriginalUrl(url : string) {
     return url === this.urlOriginal;

--- a/src/client/router/getPageByUrl.client.ts
+++ b/src/client/router/getPageByUrl.client.ts
@@ -5,10 +5,10 @@ import { getPageById } from '../getPage.client'
 
 export { getPageByUrl }
 
-async function getPageByUrl(url: string): Promise<{ Page: unknown; pageProps: Record<string, unknown> }> {
+async function getPageByUrl(url: string, useSsrCache: boolean = true): Promise<{ Page: unknown; pageProps: Record<string, unknown> }> {
   const [Page, pageProps] = await Promise.all([
-    (async () => await getPageById(await getPageId(url)))(),
-    (async () => await getPageProps(url))()
+    (async () => await getPageById(await getPageId(url, useSsrCache)))(),
+    (async () => await getPageProps(url, useSsrCache))()
   ])
   assert(pageProps.constructor === Object)
   return { Page, pageProps }

--- a/src/client/router/getPageId.client.ts
+++ b/src/client/router/getPageId.client.ts
@@ -5,8 +5,8 @@ import { navigationState } from '../navigationState.client'
 
 export { getPageId }
 
-async function getPageId(url: string): Promise<string> {
-  if (navigationState.checkIfOriginalUrl(url)) {
+async function getPageId(url: string, useSsrCache: boolean = true): Promise<string> {
+  if (navigationState.checkIfOriginalUrl(url) && useSsrCache) {
     const { pageId } = getOriginalPageInfo()
     return pageId
   } else {

--- a/src/client/router/getPageId.client.ts
+++ b/src/client/router/getPageId.client.ts
@@ -6,7 +6,7 @@ import { navigationState } from '../navigationState.client'
 export { getPageId }
 
 async function getPageId(url: string): Promise<string> {
-  if (navigationState.isFirstNavigation) {
+  if (navigationState.checkIfOriginalUrl(url)) {
     const { pageId } = getOriginalPageInfo()
     return pageId
   } else {

--- a/src/client/router/getPageProps.client.ts
+++ b/src/client/router/getPageProps.client.ts
@@ -6,11 +6,8 @@ import { getPageInfo as getOriginalPageInfo } from '../getPage.client'
 export { getPageProps }
 export { retrievePageProps }
 
-async function getPageProps(url: string, triggerNavigationChange: boolean = true): Promise<Record<string, unknown>> {
-  if (triggerNavigationChange && !navigationState.checkIfCurrentUrl(url)) {
-    navigationState.markNavigationChange();
-  }
-  if (navigationState.isFirstNavigation) {
+async function getPageProps(url: string, useSsrCache: boolean = true): Promise<Record<string, unknown>> {
+  if (navigationState.checkIfCurrentUrl(url) && useSsrCache) {
     const { pageProps } = getOriginalPageInfo()
     return pageProps
   } else {

--- a/src/client/router/getPageProps.client.ts
+++ b/src/client/router/getPageProps.client.ts
@@ -6,8 +6,11 @@ import { getPageInfo as getOriginalPageInfo } from '../getPage.client'
 export { getPageProps }
 export { retrievePageProps }
 
-async function getPageProps(url: string): Promise<Record<string, unknown>> {
-  if (navigationState.checkIfOriginalUrl(url)) {
+async function getPageProps(url: string, triggerNavigationChange: boolean = true): Promise<Record<string, unknown>> {
+  if (triggerNavigationChange && !navigationState.checkIfCurrentUrl(url)) {
+    navigationState.markNavigationChange();
+  }
+  if (navigationState.isFirstNavigation) {
     const { pageProps } = getOriginalPageInfo()
     return pageProps
   } else {

--- a/src/client/router/getPageProps.client.ts
+++ b/src/client/router/getPageProps.client.ts
@@ -7,7 +7,7 @@ export { getPageProps }
 export { retrievePageProps }
 
 async function getPageProps(url: string, useSsrCache: boolean = true): Promise<Record<string, unknown>> {
-  if (navigationState.checkIfCurrentUrl(url) && useSsrCache) {
+  if (navigationState.checkIfOriginalUrl(url) && useSsrCache) {
     const { pageProps } = getOriginalPageInfo()
     return pageProps
   } else {

--- a/src/client/router/getPageProps.client.ts
+++ b/src/client/router/getPageProps.client.ts
@@ -7,11 +7,10 @@ export { getPageProps }
 export { retrievePageProps }
 
 async function getPageProps(url: string): Promise<Record<string, unknown>> {
-  if (navigationState.isFirstNavigation) {
+  if (navigationState.checkIfOriginalUrl(url)) {
     const { pageProps } = getOriginalPageInfo()
     return pageProps
   } else {
-    navigationState.markNavigationChange()
     const pageProps = await retrievePageProps(url)
     return pageProps
   }

--- a/src/client/router/useClientRouter.client.ts
+++ b/src/client/router/useClientRouter.client.ts
@@ -1,6 +1,7 @@
 import { assert, assertUsage, hasProp, isNodejs } from '../../utils'
 import { getUrl } from '../getUrl.client'
 import { getPageByUrl } from './getPageByUrl.client'
+import navigationState from '../navigationState.client';
 
 export { useClientRouter }
 export { navigate }
@@ -184,6 +185,7 @@ function onBrowserHistoryNavigation(callback: (scrollPosition: ScrollPosition | 
 
 function changeUrl(url: string) {
   if (getUrl() === url) return
+  navigationState.markNavigationChange()
   window.history.pushState(undefined, '', url)
 }
 

--- a/src/client/router/useClientRouter.client.ts
+++ b/src/client/router/useClientRouter.client.ts
@@ -1,7 +1,7 @@
 import { assert, assertUsage, hasProp, isNodejs } from '../../utils'
 import { getUrl } from '../getUrl.client'
 import { getPageByUrl } from './getPageByUrl.client'
-import navigationState from '../navigationState.client';
+import { navigationState } from '../navigationState.client';
 
 export { useClientRouter }
 export { navigate }

--- a/src/client/router/useClientRouter.client.ts
+++ b/src/client/router/useClientRouter.client.ts
@@ -67,7 +67,7 @@ function useClientRouter({
     }
 
     const urlNow = getUrl()
-    const { Page, pageProps } = await getPageByUrl(urlNow)
+    const { Page, pageProps } = await getPageByUrl(urlNow, navigationState.isFirstNavigation)
 
     if (renderPromise) {
       // Always make sure that the previous render has finished,


### PR DESCRIPTION
This PR allows for fetching page props for a prospective new URL _before the URL has changed_. This is ideal/required when fetching data in client-side navigation hooks that occur before the navigation has completed.

Additionally, I removed the concept of "navigationChanged" for the following reasons:

- When our URL matches the initial URL, we probably DO want to serve the values cached to the DOM by the SSR process. E.g. even if we navigate off of the initial route, then go back to it, why would we make a network request for that data when it is still sitting in DOM (as it was when the app initialized)?
- It seemed strange to be setting navigation state in a method responsible for fetching data ("getPageProps" does not sound like it would/should have side effects).
