### PR TITLE
Set `as` properly on preload tags.

### DIFF
--- a/src/getPreloadTags.node.ts
+++ b/src/getPreloadTags.node.ts
@@ -93,10 +93,10 @@ function getPreloadTag(href: string): string {
   assert(href.startsWith('/'))
   assert(!href.startsWith('//'))
   if (href.endsWith('.css')) {
-    return `<link rel="stylesheet" href="${href}">`
+    return `<link rel="stylesheet" href="${href}" as="style">`
   }
   if (href.endsWith('.js')) {
-    return `<link rel="modulepreload" crossorigin href="${href}">`
+    return `<link rel="modulepreload" crossorigin href="${href}" as="script">`
   }
   return `<link rel="preload" href="${href}">`
 }


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content

Using `as` to specify the type of content to be preloaded allows the browser to:

- Prioritize resource loading more accurately.
- Store in the cache for future requests, reusing the resource if appropriate.
- Apply the correct content security policy to the resource.
- Set the correct Accept request headers for it.

It should also resolve this error in Safari (at least for the stylesheet, not so much the `svg` - open to ideas there):

<img width="644" alt="Screenshot 2021-04-19 at 18 07 13@2x" src="https://user-images.githubusercontent.com/44855/115309557-75b67900-a13a-11eb-9ed4-750cee37c85c.png">
