### PR TITLE
Fix getting scroll position from history

### DIFF
--- a/src/client/router/useClientRouter.client.ts
+++ b/src/client/router/useClientRouter.client.ts
@@ -240,7 +240,7 @@ function setScrollPosition(scrollTarget: ScrollTarget): void {
 }
 
 function getScrollPositionFromHistory(historyState: unknown = window.history.state) {
-  return hasProp(historyState, 'scrollPosition') ? (historyState.scrollPosition as ScrollPosition) : null
+  return historyState && hasProp(historyState, 'scrollPosition') ? (historyState.scrollPosition as ScrollPosition) : null
 }
 
 function autoSaveScrollPosition() {


### PR DESCRIPTION
Navigating back with the client router works only once or not all. You can try that in the **react-full** example. Run `npm run dev`, go to `http://localhost:3000`, click on a link in the menu, click the browser back button and watch the console. Either this already failed or if not go forward again. This error message appears:

```
Uncaught TypeError: can't access property "scrollPosition", obj is undefined
    hasProp hasProp.ts:22
    getScrollPositionFromHistory useClientRouter.client.ts:243
    onBrowserHistoryNavigation useClientRouter.client.ts:199
```

The problem seems to be that you set the history state to undefined in the changeUrl function:

https://github.com/brillout/vite-plugin-ssr/blob/191b073ea2c4232dfa2d7626a2f1768cd13ef3a9/src/client/router/useClientRouter.client.ts#L208

And try to get the scroll position from this now undefined object here:

https://github.com/brillout/vite-plugin-ssr/blob/191b073ea2c4232dfa2d7626a2f1768cd13ef3a9/src/client/router/useClientRouter.client.ts#L243

I just added a check if historyState exists to this line:

https://github.com/shwao/vite-plugin-ssr/blob/master/src/client/router/useClientRouter.client.ts#L243