### PR TITLE
Add webp to inferred types

### DIFF
--- a/vite-plugin-ssr/node/html/inferMediaType.ts
+++ b/vite-plugin-ssr/node/html/inferMediaType.ts
@@ -10,6 +10,7 @@ type MediaType = null | {
     | 'text/css'
     | 'image/jpeg'
     | 'image/png'
+    | 'image/webp'
     | 'image/gif'
     | 'image/svg+xml'
     | 'font/ttf'
@@ -31,6 +32,9 @@ function inferMediaType(href: string): MediaType {
   // Images
   if (href.endsWith('.png')) {
     return { preloadType: 'image', mediaType: 'image/png' }
+  }
+  if (href.endsWith('.webp')) {
+    return { preloadType: 'image', mediaType: 'image/webp' }
   }
   if (href.endsWith('.jpg') || href.endsWith('.jpeg')) {
     return { preloadType: 'image', mediaType: 'image/jpeg' }


### PR DESCRIPTION
To fix the following console warning when including webp images:

> Preload of http://localhost:3000/assets/image.webp was ignored due to unknown “as” or “type” values, or non-matching “media” attribute.