### PR TITLE
Inject link tags at the end of head or custom point

### DIFF
--- a/examples/react-full/.testPages.ts
+++ b/examples/react-full/.testPages.ts
@@ -20,6 +20,11 @@ function testPages(
     expect(html).toContain("<h1>Welcome to <code>vite-plugin-ssr</code></h1>");
   });
 
+  test("link tags are correctly injected", async () => {
+    const html = await fetchHtml("/");
+    expect(html).toMatch(/<head>.*<title>.*<link.*<\/head>/s);
+  });
+
   test("page is rendered to the DOM and interactive", async () => {
     await page.goto(urlBase + "/");
     expect(await page.textContent("h1")).toBe("Welcome to vite-plugin-ssr");

--- a/vite-plugin-ssr/node/html/injectAssets.ts
+++ b/vite-plugin-ssr/node/html/injectAssets.ts
@@ -232,10 +232,11 @@ function injectScript(htmlString: string, script: PageAsset): string {
   return injectEnd(htmlString, injection)
 }
 
+const headClose = '</head>'
 function injectLinkTags(htmlString: string, linkTags: string[]): string {
   assert(linkTags.every((tag) => tag.startsWith('<') && tag.endsWith('>')))
   const injection = linkTags.join('')
-  return injectBegin(htmlString, injection)
+  return injectAtClosingTag(htmlString, headClose, injection)
 }
 
 const headOpen = /<head[^>]*>/


### PR DESCRIPTION
Currently vite-plugin-ssr injects link tags (stylesheets, preload links, etc.) at the very start of head, before any application defined head tags.

It makes it rather difficult to use `<meta http-equiv="X-UA-Compatible" content="IE=Edge">`, which must be the first.

Also it is a bit more robust, idiomatic and performant to put `<meta charset>`, `<title>` and `<meta name="viewport">` (and other critical meta tags or resources) near the start, so that charset detection, title and layout are not blocked or delayed.

This PR changes link tags to be injected at the end of head by default, or at the verbatim string `<!-- vite-plugin-ssr-link-tags -->` (which is replaced).