### PR TITLE
feat: add disableClientRouter and restoreClientRouter

### DIFF
--- a/vite-plugin-ssr/client/router/index.ts
+++ b/vite-plugin-ssr/client/router/index.ts
@@ -1,4 +1,4 @@
 import '../page-files/setup'
-export { useClientRouter, navigate } from './useClientRouter'
+export { useClientRouter, navigate, disableClientRouter, restoreClientRouter } from './useClientRouter'
 export { prefetch } from './prefetch'
 export type { PageContextBuiltInClient } from './types'


### PR DESCRIPTION
After calling `disableClientRouter`, clicking on links or calling navigate will use server routing, even if you have called `useClientRouter`.

This is useful when e.g. you have detected that a new version of your application have been deployed, and you want the next page load to start fresh (related #151).

And `restoreClientRouter` to the reverse effect.