### PR TITLE
Add scss/sass/less to inferred types

### DIFF
--- a/vite-plugin-ssr/node/html/inferMediaType.ts
+++ b/vite-plugin-ssr/node/html/inferMediaType.ts
@@ -22,7 +22,7 @@ function inferMediaType(href: string): MediaType {
   assert(!href.startsWith('//'))
 
   // Basics
-  if (href.endsWith('.css')) {
+  if (href.match(/.*.(c|sa|sc|le)ss$/)) {
     return { mediaType: 'text/css', preloadType: 'style' }
   }
   if (href.endsWith('.js')) {


### PR DESCRIPTION
When using scss/sass/less fixes console warning (#196)

<img width="347" alt="Снимок экрана 2021-11-15 в 14 58 47" src="https://user-images.githubusercontent.com/10296831/141778365-a12b5d33-7349-4b69-943a-fb0483e50b38.png">

and makes SSR css to load with html in dev mode which removes page flickering and layout shifting after client css is loaded