### PR TITLE
[Fix] Bundle app before deploying to Vercel

### DIFF
--- a/examples/vercel/package.json
+++ b/examples/vercel/package.json
@@ -6,6 +6,7 @@
     "dev": "node ./dev-server"
   },
   "dependencies": {
+    "@vercel/ncc": "0.32.0",
     "@vitejs/plugin-vue": "^1.2.3",
     "@vue/compiler-sfc": "^3.0.11",
     "@vue/server-renderer": "^3.0.11",

--- a/examples/vercel/vercel/deploy.sh
+++ b/examples/vercel/vercel/deploy.sh
@@ -15,10 +15,10 @@ mkdir .output
 mkdir -p .output/static
 cp -a dist/client/. .output/static
 
-# Step 5: Copy render function and rename it to index.js
-# If you are using typescript, you should transpile it to javascript
+# Step 5: Bundle render function with it's depdendencies to the single javascript file
+# If you are using typescript, simply replace extension with ".ts"
 mkdir -p .output/server/pages
-cp -a vercel/render.js .output/server/pages/index.js
+yarn ncc build vercel/render.js --minify --out .output/server/pages
 
 # Step 6: Make render function run on every request (catch all)
 cat > .output/routes-manifest.json << EOF

--- a/yarn.lock
+++ b/yarn.lock
@@ -1275,6 +1275,11 @@
     "@graphql-typed-document-node/core" "^3.1.0"
     wonka "^4.0.14"
 
+"@vercel/ncc@0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.32.0.tgz#42faafe0f41ea2a8e857785c10a31ef122f2416e"
+  integrity sha512-S/SxTHHTbBQSOutpgnqEn+LyTfZcq9xMRAnzY05HpGVjxjmfmvg6SWZZkbW/GJIFznMmHGeGOrI1MEBD7efIkA==
+
 "@vitejs/plugin-react@^1.0.4":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-1.0.5.tgz#8da501137078c8cb791cf2611f23de7b96ad5494"


### PR DESCRIPTION
I made some assumptions when updating javascript example, based on my typescript project. It turned out that it didn't work. Theoretically, Vercel should bundle javascript serverless functions on their side, but they do not do that. This PR adds another step in deployment process, which uses [@vercel/ncc](https://github.com/vercel/ncc) tool which bundles entire app to a single, lambda-friendly file.