### PR TITLE
Fixed broken link to workflow example

### DIFF
--- a/docs/pages/github-pages.page.mdx
+++ b/docs/pages/github-pages.page.mdx
@@ -8,7 +8,7 @@ import { RepoLink } from 'libframe-docs/components/RepoLink'
 We add an empty file `.nojekyll` to avoid [GitHub Pages ignoring files starting with `_`](https://stackoverflow.com/questions/6397780/names-starting-with-underscore-shows-errors-page-doesnot-exists-for-gh-pages-bra) which breaks files such as `_default.page.client.js`.
 
 We recommend using the [GitHub Pages Deploy Action](https://github.com/JamesIves/github-pages-deploy-action), for example:
-- `vite-plugin-ssr.com`'s GitHub Action that automatically deploys to GitHub Pages: <RepoLink path='.github/workflows/docs-website.yml' />.
+- `vite-plugin-ssr.com`'s GitHub Action that automatically deploys to GitHub Pages: <RepoLink path='.github/workflows/docs.yml' />.
 
 <StaticHostDocOutro
   baseUrlAddendum={<> E.g. we need to do this if we use GitHub Page's default deployment to <code><i>username</i>.github.io/<i>repo-name/*</i></code>.</>}


### PR DESCRIPTION
The `vite-plugin-ssr.com`  link to workflow example was pointing to a 404 Page.

https://github.com/brillout/vite-plugin-ssr/blob/master/.github/workflows/docs-website.yml

Instead of:

https://github.com/brillout/vite-plugin-ssr/blob/master/.github/workflows/docs.yml