### PR TITLE
Fixed typo in code example

### DIFF
--- a/docs/pages/catch-all.page.mdx
+++ b/docs/pages/catch-all.page.mdx
@@ -10,7 +10,7 @@ We can use [Route Strings](/route-string) and [Route Functions](/route-function)
 // `/product/1337/details`
 // `/product/2048/some/deeply/nested/path`
 //  ...
-export default '/product/*`
+export default '/product/*'
 ```
 
 The value of the catch-all is available at `pageContext.routeParams['*']`.


### PR DESCRIPTION
## Reference Issues/PRs

none

## What does this implement/fix?

- Fixed typo in line 13

```js
export default '/product/*`
```