### PR TITLE
Fix duplicate decodeURI logic

### DIFF
--- a/vite-plugin-ssr/utils/parseUrl.ts
+++ b/vite-plugin-ssr/utils/parseUrl.ts
@@ -72,8 +72,8 @@ function parseUrl(
   hash: string
   hashString: null | string
 } {
-  url = decodeURI(url)
   assert(isParsable(url), { url })
+  url = decodeURI(url)
   assert(baseUrl.startsWith('/'), { url, baseUrl })
 
   // Hash


### PR DESCRIPTION
The current code uses `decodeURI` on `url` then asserts that it `isParsable` which does a second `decodeURI`. If the initial decoded URI contains a `%` character, the second `decodeURI` in `isParsable` will fail. Asserting `isParsable` before the `decodeURI` in `parseUrl` allows a `url` containing a decoded `%` character to be parsed successfully.