### PR TITLE
Fixed typo in the documentation for Nested Routes

### DIFF
--- a/docs/pages/nested-routes.page.mdx
+++ b/docs/pages/nested-routes.page.mdx
@@ -45,7 +45,7 @@ Usually, the sub route is used for navigating some (deeply) nested view:
 
 > If our sub routes don't need URLs (the Product Pricing page and the Product Reviews page share the same URL `/product/42`), then we can simply use a stateful component instead. (When the user clicks on a "pricing" link, the stateful component changes an internal state `productView` to `'pricing'` to switch to the pricing view.)
 
-## Cient Rendering
+## Client Rendering
 
 For smooth nested routes, we recommend using <Link href="/client-routing" noBreadcrumb={true} />.
 


### PR DESCRIPTION
Changed the typo "Cient rendering" to "Client rendering" at line 48.