### PR TITLE
fix: typo on craftsmanship

### DIFF
--- a/docs/pages/index/features/Features.tsx
+++ b/docs/pages/index/features/Features.tsx
@@ -281,7 +281,7 @@ function Features() {
         {
           title: (
             <>
-              <Emoji name="red-heart" /> Craftmanship
+              <Emoji name="red-heart" /> Craftsmanship
             </>
           ),
           desc: (


### PR DESCRIPTION
Just a typo on `Craftsmanship` a S was missing.
Thanks a lot for this amazing work 👌🏻 