### PR TITLE
fix: isolate framework pageFiles symlink directory

### DIFF
--- a/vite-plugin-ssr/node/plugin/plugins/generateImportGlobs/getGlobRoots.ts
+++ b/vite-plugin-ssr/node/plugin/plugins/generateImportGlobs/getGlobRoots.ts
@@ -52,7 +52,7 @@ async function createIncludePath(pkgName: string, root: string): Promise<string>
     return includePath
   }
 
-  const includePath = path.posix.join('node_modules', pkgName, pageFilesDir)
+  const includePath = path.posix.join('node_modules', '.vite-plugin-ssr', pkgName, pageFilesDir)
   if (!fs.existsSync(includePath)) {
     const sourceAbsolute = crawlRoot
     const targetAbsolute = `${root}/${includePath}`


### PR DESCRIPTION
> VPS symlinking the framework pageFilesDir to node_modules breaks exports from the framework (since it doesn't copy contents other than pageFilesDir, which  means that files including package.json is not there)

Fixes issue [mentioned here](https://discord.com/channels/815937377888632913/815937377888632916/969417390771290182)