### PR TITLE
add support for urls to start with . to allow raw html files to impor…

### DIFF
--- a/vite-plugin-ssr/node/renderPage.ts
+++ b/vite-plugin-ssr/node/renderPage.ts
@@ -1078,7 +1078,7 @@ function isFileRequest(urlPathname: string) {
 
 function _parseUrl(url: string, baseUrl: string): ReturnType<typeof parseUrl> & { isPageContextRequest: boolean } {
   assert(url.startsWith('/') || url.startsWith('http'))
-  assert(baseUrl.startsWith('/'))
+  assert(baseUrl.startsWith('/') || baseUrl.startsWith('.'))
   const { urlWithoutPageContextRequestSuffix, isPageContextRequest } = handlePageContextRequestSuffix(url)
   return { ...parseUrl(urlWithoutPageContextRequestSuffix, baseUrl), isPageContextRequest }
 }

--- a/vite-plugin-ssr/shared/addComputedUrlProps.ts
+++ b/vite-plugin-ssr/shared/addComputedUrlProps.ts
@@ -41,7 +41,7 @@ function addComputedUrlProps<PageContext extends Record<string, unknown> & PageC
 type PageContextUrlSource = { url: string; _baseUrl: string; _parseUrl: null | typeof parseUrl }
 function getUrlParsed(pageContext: PageContextUrlSource) {
   const { url, _baseUrl: baseUrl, _parseUrl } = pageContext
-  assert(baseUrl.startsWith('/'))
+  assert(baseUrl.startsWith('/') || baseUrl.startsWith('.'))
   assert(_parseUrl === null || isCallable(pageContext._parseUrl))
   if (_parseUrl === null) {
     return parseUrl(url, baseUrl)

--- a/vite-plugin-ssr/utils/parseUrl.ts
+++ b/vite-plugin-ssr/utils/parseUrl.ts
@@ -74,7 +74,7 @@ function parseUrl(
 } {
   assert(isParsable(url), { url })
   url = decodeURI(url)
-  assert(baseUrl.startsWith('/'), { url, baseUrl })
+  assert(baseUrl.startsWith('/') || baseUrl.startsWith('.'), { url, baseUrl })
 
   // Hash
   const [urlWithoutHash, ...hashList] = url.split('#')
@@ -185,7 +185,7 @@ function assertUsageBaseUrl(baseUrl: string, usageErrorMessagePrefix: string = '
 }
 
 function assertBaseUrl(baseUrl: string) {
-  assert(baseUrl.startsWith('/'))
+  assert(baseUrl.startsWith('/') || baseUrl.startsWith('.'))
 }
 
 function assertUrlPathname(urlPathname: string) {
@@ -205,7 +205,7 @@ function analyzeBaseUrl(
   let url = urlPathnameWithBase
 
   assert(url.startsWith('/'))
-  assert(baseUrl.startsWith('/'))
+  assert(baseUrl.startsWith('/') || baseUrl.startsWith('.'))
 
   if (baseUrl === '/') {
     const pathnameWithoutBaseUrl = urlPathnameWithBase


### PR DESCRIPTION
**URL Format Validation Update**

The below changes add support for urls, such as assets imports to start with a . eg: `./assets/file.ext`.

Use case for these changes are when using ssg simply to generate raw html and wanting to serve the html files outside vue's ssr. This will allow the html files to bind the assets correctly rather than relying on ssr.

Currently the generated html will bind paths such as:
<img width="1121" alt="Screen Shot 2022-05-06 at 11 18 19 AM" src="https://user-images.githubusercontent.com/49913937/167189400-25bc1411-809a-46cc-afa1-0eec32eca05d.png">

the update would output the paths like:

<img width="1036" alt="Screen Shot 2022-05-06 at 11 52 18 AM" src="https://user-images.githubusercontent.com/49913937/167189512-1dc2bf1a-515a-4081-a616-38febe25cae0.png">

