### PR TITLE
fix: add rollup esm aliases to dist/server output

### DIFF
--- a/vite-plugin-ssr/node/plugin/packageJsonFile.ts
+++ b/vite-plugin-ssr/node/plugin/packageJsonFile.ts
@@ -56,7 +56,8 @@ function getIsEsmOutput(config: {
   if (Array.isArray(output)) {
     return null
   } else {
-    if (output.format === 'es') {
+    const { format } = output
+    if (format === 'es' || format === 'esm' || format === 'module') {
       return true
     }
   }


### PR DESCRIPTION
Hello! Thanks for all your hard work on this library. I've been really enjoying trying it out on a few projects.

I ran into a little problem today where my `dist/server/package.json` was output with `{ "type": "commonjs" }` even though my `vite.config.js` was set to `build.rollupOptions.output.format: 'esm'`. Upon investigation, I discovered that this package will only set `type: module` if `output.format` is _exactly_ `es`. Rollup, however, [accepts `esm` and `module`](https://rollupjs.org/guide/en/#outputformat) as valid aliases for `es`:

> `es` – Keep the bundle as an ES module file, suitable for other bundlers and inclusion as a `<script type=module>` tag in modern browsers (alias: `esm`, `module`)

This PR adds those valid aliases to the check in `packageJsonFile.ts`.

I looked at [the commit that added this check](https://github.com/brillout/vite-plugin-ssr/commit/449933089f9d9708830b8b12e6a2413c48c32f90) and the [subsequent commit](https://github.com/brillout/vite-plugin-ssr/commit/09a4012cacb339ebcc587ae06f11049ca38d3066) that modified an example to test this behavior, but I wasn't sure the best way to add a test for my addition. I'm more than happy to add tests to this PR if you could point me in the right direction!
