### PR TITLE
fix apollo cache in .page.server (vue apollo example)

### DIFF
--- a/examples/graphql-apollo-vue/rendered/_default.page.client.js
+++ b/examples/graphql-apollo-vue/rendered/_default.page.client.js
@@ -11,7 +11,7 @@ async function hydrate() {
   const pageContext = await getPage()
   const defaultClient = new ApolloClient({
     link: new HttpLink({ uri: 'https://rickandmortyapi.com/graphql', fetch }),
-    cache: new InMemoryCache().restore(pageContext.apolloIntialState),
+    cache: new InMemoryCache().restore(pageContext.apolloInitialState),
     connectToDevTools: true,
   })
 

--- a/examples/graphql-apollo-vue/rendered/_default.page.server.js
+++ b/examples/graphql-apollo-vue/rendered/_default.page.server.js
@@ -6,7 +6,7 @@ import logoUrl from './logo.svg'
 export { render }
 export { onBeforeRender }
 // See https://vite-plugin-ssr.com/data-fetching
-export const passToClient = ['pageProps', 'urlPathname', 'apolloIntialState']
+export const passToClient = ['pageProps', 'urlPathname', 'apolloInitialState']
 
 async function render(pageContext) {
   // See https://vite-plugin-ssr.com/head
@@ -40,11 +40,11 @@ async function render(pageContext) {
 
 async function onBeforeRender(pageContext) {
   const app = createApp(pageContext, pageContext.apolloClient)
-  const apolloIntialState = pageContext.apolloClient.extract()
   const appHtml = await renderToString(app)
+  const apolloInitialState = pageContext.apolloClient.extract()
   return {
     pageContext: {
-      apolloIntialState,
+      apolloInitialState,
       appHtml,
     },
   }


### PR DESCRIPTION
Hello. In graphql-view example console.log outputs an error, because the server side passes an empty cache object.
This pull request fix it.


