### PR TITLE
Export helpers needed by vite-plugin-vercel vps integration

### DIFF
--- a/vite-plugin-ssr/__internal.ts
+++ b/vite-plugin-ssr/__internal.ts
@@ -1,0 +1,34 @@
+// Internal functions of vps needed by other plugins are exported via this file
+
+import { loadPageRoutes, PageRoutes, route } from './shared/route'
+import { getPageFilesAllServerSide, PageFile } from './shared/getPageFiles'
+import { getGlobalContext } from './node/globalContext'
+import { setProductionEnvVar } from './shared/setProduction'
+
+export { route, getPagesAndRoutes }
+export type { PageRoutes, PageFile }
+
+/**
+ * Used by {@link https://github.com/magne4000/vite-plugin-vercel|vite-plugin-vercel}
+ * to compute some rewrite rules and extract { isr } configs.
+ * Needs `import 'vite-plugin-ssr/__internal/setup'`
+ * @param config
+ */
+async function getPagesAndRoutes() {
+  setProductionEnvVar()
+  await getGlobalContext(true)
+
+  const { pageFilesAll, allPageIds } =
+    await getPageFilesAllServerSide(true)
+
+  const { pageRoutes } = await loadPageRoutes({
+    _pageFilesAll: pageFilesAll,
+    _allPageIds: allPageIds,
+  })
+
+  return {
+    pageRoutes,
+    pageFilesAll,
+    allPageIds,
+  }
+}

--- a/vite-plugin-ssr/node/prerender.ts
+++ b/vite-plugin-ssr/node/prerender.ts
@@ -30,6 +30,7 @@ import { getGlobalContext, GlobalContext } from './globalContext'
 import { resolveConfig } from 'vite'
 import { assertConfigVpsResolved } from './plugin/plugins/config/assertConfigVps'
 import type { InlineConfig } from 'vite'
+import { setProductionEnvVar } from '../shared/setProduction'
 
 export { prerender }
 
@@ -650,13 +651,6 @@ function checkOutdatedOptions(options: {
     parallel === undefined || parallel,
     `[prerender()] Option \`parallel\` should be a number \`>=1\` but we got \`${parallel}\`.`,
   )
-}
-
-function setProductionEnvVar() {
-  // The statement `process.env['NODE_ENV'] = 'production'` chokes webpack v4 (which Cloudflare Workers uses)
-  const proc = process
-  const { env } = proc
-  env['NODE_ENV'] = 'production'
 }
 
 function throwPrerenderError(err: unknown) {

--- a/vite-plugin-ssr/node/tsconfig.json
+++ b/vite-plugin-ssr/node/tsconfig.json
@@ -5,5 +5,5 @@
     "target": "ES2017",
     "module": "CommonJS"
   },
-  "include": ["../node/**/*", "../shared/**/*", "../utils/**/*"]
+  "include": ["../node/**/*", "../shared/**/*", "../utils/**/*", "../__internal.ts"]
 }

--- a/vite-plugin-ssr/package.json
+++ b/vite-plugin-ssr/package.json
@@ -66,17 +66,10 @@
     "./plugin": {
       "node": "./dist/cjs/node/plugin/index.js"
     },
-    "./shared/route": {
-      "worker": "./dist/cjs/shared/route.js",
-      "node": "./dist/cjs/shared/route.js",
-      "browser": "./dist/esm/client/node.js"
+    "./__internal": {
+      "node": "./dist/cjs/__internal.js"
     },
-    "./shared/getPageFiles": {
-      "worker": "./dist/cjs/shared/getPageFiles.js",
-      "node": "./dist/cjs/shared/getPageFiles.js",
-      "browser": "./dist/esm/client/getPageFiles.js"
-    },
-    "./page-files/setup": {
+    "./__internal/setup": {
       "node": "./dist/cjs/node/page-files/setup.js"
     }
   },

--- a/vite-plugin-ssr/package.json
+++ b/vite-plugin-ssr/package.json
@@ -65,6 +65,19 @@
     },
     "./plugin": {
       "node": "./dist/cjs/node/plugin/index.js"
+    },
+    "./shared/route": {
+      "worker": "./dist/cjs/shared/route.js",
+      "node": "./dist/cjs/shared/route.js",
+      "browser": "./dist/esm/client/node.js"
+    },
+    "./shared/getPageFiles": {
+      "worker": "./dist/cjs/shared/getPageFiles.js",
+      "node": "./dist/cjs/shared/getPageFiles.js",
+      "browser": "./dist/esm/client/getPageFiles.js"
+    },
+    "./page-files/setup": {
+      "node": "./dist/cjs/node/page-files/setup.js"
     }
   },
   "files": [

--- a/vite-plugin-ssr/shared/setProduction.ts
+++ b/vite-plugin-ssr/shared/setProduction.ts
@@ -1,0 +1,8 @@
+export { setProductionEnvVar }
+
+function setProductionEnvVar() {
+  // The statement `process.env['NODE_ENV'] = 'production'` chokes webpack v4 (which Cloudflare Workers uses)
+  const proc = process
+  const { env } = proc
+  env['NODE_ENV'] = 'production'
+}


### PR DESCRIPTION
- `page-files/setup`: For other helpers to work
- `shared/route`: Need `loadPageRoutes` and `route` functions
- `shared/getPageFiles`: Need `getPageFilesAllServerSide`

Will be mergeable when `vite-plugin-vercel` compiles correctly and without hacks.