### PR TITLE
chore: add sourcemap for debug

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -824,6 +824,7 @@ importers:
       p-limit: ^3.1.0
       picocolors: ^1.0.0
       resolve: ^1.22.0
+      rimraf: ^3.0.2
       rollup: ^2.71.1
       symlink-dir: ^5.0.1
       typescript: 4.6.4
@@ -849,6 +850,7 @@ importers:
       '@types/jest': 27.4.1
       '@types/node': 17.0.31
       '@types/resolve': 1.20.2
+      rimraf: 3.0.2
       rollup: 2.71.1
       typescript: 4.6.4
       vite: 2.9.14
@@ -3415,7 +3417,6 @@ packages:
 
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: false
 
   /balloon-css/1.2.0:
     resolution: {integrity: sha512-urXwkHgwp6GsXVF+it01485Z2Cj4pnW02ICnM0TemOlkKmCNnDLmyy+ZZiRXBpwldUXO+aRNr7Hdia4CBvXJ5A==}
@@ -3477,7 +3478,6 @@ packages:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-    dev: false
 
   /braces/3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -3896,7 +3896,6 @@ packages:
 
   /concat-map/0.0.1:
     resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
-    dev: false
 
   /concurrently/7.1.0:
     resolution: {integrity: sha512-Bz0tMlYKZRUDqJlNiF/OImojMB9ruKUz6GCfmhFnSapXgPe+3xzY4byqoKG9tUZ7L2PGEUjfLPOLfIX3labnmw==}
@@ -5372,7 +5371,6 @@ packages:
 
   /fs.realpath/1.0.0:
     resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
-    dev: false
 
   /fsevents/2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -5516,7 +5514,6 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
-    dev: false
 
   /global-dirs/3.0.0:
     resolution: {integrity: sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==}
@@ -5881,11 +5878,9 @@ packages:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
-    dev: false
 
   /inherits/2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: false
 
   /ini/1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
@@ -7764,7 +7759,6 @@ packages:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
-    dev: false
 
   /minimist-options/4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
@@ -8200,7 +8194,6 @@ packages:
     resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
     dependencies:
       wrappy: 1.0.2
-    dev: false
 
   /onetime/5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -8433,7 +8426,6 @@ packages:
   /path-is-absolute/1.0.1:
     resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /path-is-inside/1.0.2:
     resolution: {integrity: sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=}
@@ -9270,7 +9262,6 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.0
-    dev: false
 
   /rollup-plugin-inject/3.0.2:
     resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
@@ -10956,7 +10947,6 @@ packages:
 
   /wrappy/1.0.2:
     resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
-    dev: false
 
   /write-file-atomic/3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}

--- a/vite-plugin-ssr/package.json
+++ b/vite-plugin-ssr/package.json
@@ -17,7 +17,7 @@
     "vite-plugin-glob": "0.2.8"
   },
   "scripts": {
-    "build": "rm -rf dist/ && tsc -b",
+    "build": "rimraf dist/ && tsc -b",
     "dev": "pnpm run dev:slow",
     "dev:node": "pnpm run tsc:watch:node",
     "// `dev:fast` and `dev:slow` achieve the same, but `dev:fast` is much faster": "",
@@ -33,6 +33,7 @@
     "@types/resolve": "^1.20.2",
     "rollup": "^2.71.1",
     "typescript": "4.6.4",
+    "rimraf": "^3.0.2",
     "vite": "^2.9.14"
   },
   "peerDependencies": {
@@ -89,7 +90,8 @@
     "__internal.d.ts",
     "__internal/setup.js",
     "__internal/setup.d.ts",
-    "types.d.ts"
+    "types.d.ts",
+    "!*.map"
   ],
   "bin": {
     "vite-plugin-ssr": "./node/bin/vite-plugin-ssr.js"

--- a/vite-plugin-ssr/tsconfig.base.json
+++ b/vite-plugin-ssr/tsconfig.base.json
@@ -11,7 +11,9 @@
     "noEmitOnError": false,
     // Misc
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    // SourceMap
+    "sourceMap": true
   },
   "exclude": ["**/*.d.ts", "**/*.spec.ts", "**/node_modules", "**/.*/"]
 }


### PR DESCRIPTION
I'm learning the source code for VPS, and I found local debugging inconvenient, so I did these things:
1. add typescript sourcemap, and ignore `.map` from `npm publish`
2. replace `rimraf` for `rm -rf` as windows do not support it.

Sorry for my bad english. If I did something wrong, please tell me!