### PR TITLE
fix: make onPagePrerender pageContext concurrent safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ env:
 on:
   push:
   pull_request:
-    types: [opened, reopened] # Avoid GitHub Actions being run twice
 
 jobs:
   prepare:

--- a/vite-plugin-ssr/node/prerender.ts
+++ b/vite-plugin-ssr/node/prerender.ts
@@ -612,7 +612,8 @@ function write(
     const filePath = join(root, outDirRoot, 'client', filePathRelative)
     if (onPagePrerender) {
       const prerenderPageContext = {}
-      objectAssign(prerenderPageContext, pageContext, {
+      objectAssign(prerenderPageContext, pageContext)
+      objectAssign(prerenderPageContext, {
         _prerenderResult: {
           filePath,
           fileContent,

--- a/vite-plugin-ssr/node/prerender.ts
+++ b/vite-plugin-ssr/node/prerender.ts
@@ -611,13 +611,14 @@ function write(
     assert(!outDirRoot.includes('\\'))
     const filePath = join(root, outDirRoot, 'client', filePathRelative)
     if (onPagePrerender) {
-      objectAssign(pageContext, {
+      const prerenderPageContext = {}
+      objectAssign(prerenderPageContext, pageContext, {
         _prerenderResult: {
           filePath,
           fileContent,
         },
       })
-      await onPagePrerender(pageContext)
+      await onPagePrerender(prerenderPageContext)
     } else {
       const { promises } = require('fs')
       const { writeFile, mkdir } = promises

--- a/vite-plugin-ssr/utils/objectAssign.ts
+++ b/vite-plugin-ssr/utils/objectAssign.ts
@@ -1,9 +1,9 @@
 export { objectAssign }
 
 // Same as `Object.assign()` but with type inference
-function objectAssign<Obj extends object, ObjAddendum>(
+function objectAssign<Obj extends object, ObjAddendum, T extends any[]>(
   obj: Obj,
-  objAddendum: ObjAddendum,
-): asserts obj is Obj & ObjAddendum {
-  Object.assign(obj, objAddendum)
+  ...objAddendum: [ObjAddendum, ...T]
+): asserts obj is Obj & ObjAddendum & ([] extends T ? {} : T[number]) {
+  Object.assign(obj, ...objAddendum)
 }

--- a/vite-plugin-ssr/utils/objectAssign.ts
+++ b/vite-plugin-ssr/utils/objectAssign.ts
@@ -1,9 +1,9 @@
 export { objectAssign }
 
 // Same as `Object.assign()` but with type inference
-function objectAssign<Obj extends object, ObjAddendum, T extends any[]>(
+function objectAssign<Obj extends object, ObjAddendum>(
   obj: Obj,
-  ...objAddendum: [ObjAddendum, ...T]
-): asserts obj is Obj & ObjAddendum & ([] extends T ? {} : T[number]) {
-  Object.assign(obj, ...objAddendum)
+  objAddendum: ObjAddendum,
+): asserts obj is Obj & ObjAddendum {
+  Object.assign(obj, objAddendum)
 }


### PR DESCRIPTION
While working on `vite-plugin-vercel` I noticed that prerender was only generating `.pageContext.json` files, twice.

Same `pageContext` is used for a page `.html` and `.pageContext.json`, resulting in `_prerenderResult` being overwritten in parallel runs, before `onPagePrerender` finishes its execution.

`objectAssign` can also now take any number of args, like `Object.assign` would.