### PR TITLE
Fix minor documentProps error

### DIFF
--- a/boilerplates/boilerplate-react-ts/renderer/_default.page.server.tsx
+++ b/boilerplates/boilerplate-react-ts/renderer/_default.page.server.tsx
@@ -19,7 +19,7 @@ async function render(pageContext: PageContextBuiltIn & PageContext) {
   )
 
   // See https://vite-plugin-ssr.com/head
-  const { documentProps } = pageContext
+  const { documentProps } = pageContext.exports
   const title = (documentProps && documentProps.title) || 'Vite SSR app'
   const desc = (documentProps && documentProps.description) || 'App using Vite + vite-plugin-ssr'
 

--- a/boilerplates/boilerplate-react-ts/renderer/types.ts
+++ b/boilerplates/boilerplate-react-ts/renderer/types.ts
@@ -2,7 +2,7 @@ export type PageProps = {}
 // The `pageContext` that are available in both on the server-side and browser-side
 export type PageContext = {
   Page: (pageProps: PageProps) => React.ReactElement
-  pageProps: PageProps
+  pageProps?: PageProps
   urlPathname: string
   exports: {
     documentProps?: {

--- a/boilerplates/boilerplate-react-ts/renderer/types.ts
+++ b/boilerplates/boilerplate-react-ts/renderer/types.ts
@@ -4,8 +4,10 @@ export type PageContext = {
   Page: (pageProps: PageProps) => React.ReactElement
   pageProps: PageProps
   urlPathname: string
-  documentProps?: {
-    title?: string
-    description?: string
+  exports: {
+    documentProps?: {
+      title?: string;
+      description?: string;
+    }
   }
 }

--- a/boilerplates/boilerplate-react/renderer/_default.page.server.jsx
+++ b/boilerplates/boilerplate-react/renderer/_default.page.server.jsx
@@ -17,7 +17,7 @@ async function render(pageContext) {
   )
 
   // See https://vite-plugin-ssr.com/head
-  const { documentProps } = pageContext
+  const { documentProps } = pageContext.exports
   const title = (documentProps && documentProps.title) || 'Vite SSR app'
   const desc = (documentProps && documentProps.description) || 'App using Vite + vite-plugin-ssr'
 

--- a/boilerplates/boilerplate-vue-ts/renderer/_default.page.server.ts
+++ b/boilerplates/boilerplate-vue-ts/renderer/_default.page.server.ts
@@ -14,7 +14,7 @@ async function render(pageContext: PageContextBuiltIn & PageContext) {
   const appHtml = await renderToString(app)
 
   // See https://vite-plugin-ssr.com/head
-  const { documentProps } = pageContext
+  const { documentProps } = pageContext.exports
   const title = (documentProps && documentProps.title) || 'Vite SSR app'
   const desc = (documentProps && documentProps.description) || 'App using Vite + vite-plugin-ssr'
 

--- a/boilerplates/boilerplate-vue-ts/renderer/types.ts
+++ b/boilerplates/boilerplate-vue-ts/renderer/types.ts
@@ -3,9 +3,11 @@ export type PageProps = {}
 export type PageContext = {
   Page: any
   pageProps?: PageProps
-  documentProps?: {
-    title?: string
-    description?: string
+  urlPathname: string
+  exports: {
+    documentProps?: {
+      title?: string;
+      description?: string;
+    }
   }
-  urlPathname?: string
 }

--- a/boilerplates/boilerplate-vue/renderer/_default.page.server.js
+++ b/boilerplates/boilerplate-vue/renderer/_default.page.server.js
@@ -12,7 +12,7 @@ async function render(pageContext) {
   const appHtml = await renderToString(app)
 
   // See https://vite-plugin-ssr.com/head
-  const { documentProps } = pageContext
+  const { documentProps } = pageContext.exports
   const title = (documentProps && documentProps.title) || 'Vite SSR app'
   const desc = (documentProps && documentProps.description) || 'App using Vite + vite-plugin-ssr'
 


### PR DESCRIPTION
[Line 24](https://github.com/brillout/vite-plugin-ssr/blob/158059610a9a76611b5f43576dcee6b1e8ab0f92/boilerplates/boilerplate-react-ts/renderer/_default.page.server.tsx#L24): 

```
const { documentProps } = pageContext;
const title = (documentProps && documentProps.title) || 'Vite SSR app';
```

I believe this should be `const { documentProps } = pageContext.exports;`

Which also needs to be resolved downstream in ./types.ts