### PR TITLE
fix: disposing of previous page

### DIFF
--- a/examples/solid-spa/renderer/_default.page.client.tsx
+++ b/examples/solid-spa/renderer/_default.page.client.tsx
@@ -3,7 +3,22 @@ export { render }
 import { render as renderSolid } from 'solid-js/web'
 import type { PageContextClient } from './types'
 
+/**
+ * A function that disposes previously rendered pages.
+ *
+ * If the function is not executed, each route change will
+ * append a page to the DOM without clearing (disposing)
+ * the previous one.
+ */
+let disposePreviousPage: () => void
+
 async function render(pageContext: PageContextClient) {
   const { Page } = pageContext
-  return renderSolid(() => <Page />, document.getElementById('root') as HTMLElement)
+
+  if (disposePreviousPage) {
+    disposePreviousPage()
+  }
+
+  // render the page and save the dispose function of that page
+  disposePreviousPage = renderSolid(() => <Page />, document.getElementById('root'))
 }


### PR DESCRIPTION
Fixes a bug in #430. 

Each route change resulted in appending DOM nodes without the disposal of previous DOM nodes.
  

https://user-images.githubusercontent.com/35429197/188263852-8b700add-c211-4bb8-aac9-3e1fe3fb1c3c.mov

