### PR TITLE
fix: make streaming SSR work on Firefox

### DIFF
--- a/docs/pages/renderPage.page.server.mdx
+++ b/docs/pages/renderPage.page.server.mdx
@@ -46,7 +46,7 @@ async function startServer() {
 ```
 
 - `pageContext.httpResponse.statusCode` is either `200`, `404`, or `500`.
-- `pageContext.httpResponse.contentType` is either `text/html` or `application/json`. (The `Content-Type` is `application/json` when <Link text="Client Routing" href="/client-routing" /> fetches the `pageContext` of the newly navigated page.)
+- `pageContext.httpResponse.contentType` is either `text/html;charset=utf-8` or `application/json`. (The `Content-Type` is `application/json` when <Link text="Client Routing" href="/client-routing" /> fetches the `pageContext` of the newly navigated page.)
 - `pageContext.httpResponse.body` is the HTML string returned by the <Link text={<><code>render()</code> hook</>} href="/render" /> with additional `<script>` and `<style>` tags automatically injected by `vite-plugin-ssr`.
 - `pageContext.httpResponse` is `null` if:
    - An error occurs while rendering the page and you didn't create an `_error.page.js` file.

--- a/test/renderPage.spec.ts
+++ b/test/renderPage.spec.ts
@@ -12,7 +12,7 @@ describe('renderPage()', () => {
       const pageContext = await renderPage({ url: '/' })
       const { body, statusCode, contentType } = pageContext.httpResponse
       expect(statusCode).toBe(200)
-      expect(contentType).toBe('text/html')
+      expect(contentType).toBe('text/html;charset=utf-8')
       expect(body).toBe(
         `<html><head></head><body>hello<script type=\"module\" src=\"/@vite/client\"></script></body></html>`
       )

--- a/vite-plugin-ssr/node/renderPage.ts
+++ b/vite-plugin-ssr/node/renderPage.ts
@@ -315,7 +315,7 @@ function assertError(err: unknown) {
 }
 
 type StatusCode = 200 | 404 | 500
-type ContentType = 'application/json' | 'text/html'
+type ContentType = 'application/json' | 'text/html;charset=utf-8'
 type HttpResponse = {
   statusCode: StatusCode
   contentType: ContentType
@@ -365,7 +365,7 @@ function createHttpResponseObject(
 
   return {
     statusCode,
-    contentType: pageContext._isPageContextRequest ? 'application/json' : 'text/html',
+    contentType: pageContext._isPageContextRequest ? 'application/json' : 'text/html;charset=utf-8',
     get body() {
       if (typeof htmlRender !== 'string') {
         assert(renderFilePath)


### PR DESCRIPTION
This PR fixes streaming SSR on Firefox.

Firefox streams the HTML content only if `Content-Type` has `charset`, therefore the previous version didn't do streaming SSR on Firefox since `contentType` was `text/html` which doesn't include `charset`. 