### PR TITLE
Improve getTagClosing performance

### DIFF
--- a/vite-plugin-ssr/node/html/injectAssets/injectHtmlSnippet.ts
+++ b/vite-plugin-ssr/node/html/injectAssets/injectHtmlSnippet.ts
@@ -98,13 +98,17 @@ function injectAtClosingTag(tag: 'head' | 'body' | 'html', htmlString: string, h
   assert(tagClosingExists(tag, htmlString))
 
   const tagClosing = getTagClosing(tag)
-  const htmlParts = htmlString.split(tagClosing)
+  const matches = htmlString.match(tagClosing)
+  assert(matches && matches.length >= 1)
+  const tagInstance = matches[0]
+  assert(tagInstance)
+  const htmlParts = htmlString.split(tagInstance)
   assert(htmlParts.length >= 2)
 
   // Insert `htmlSnippet` before last `tagClosing`
-  const before = slice(htmlParts, 0, -1).join(tagClosing)
+  const before = slice(htmlParts, 0, -1).join(tagInstance)
   const after = slice(htmlParts, -1, 0)
-  return before + htmlSnippet + tagClosing + after
+  return before + htmlSnippet + tagInstance + after
 }
 
 function createHtmlHeadIfMissing(htmlString: string): string {
@@ -140,14 +144,14 @@ function tagOpeningExists(tag: Tag, htmlString: string) {
   return tagOpeningRE.test(htmlString)
 }
 function tagClosingExists(tag: Tag, htmlString: string) {
-  const tagClosing = getTagClosing(tag)
-  return htmlString.toLowerCase().includes(tagClosing.toLowerCase())
+  const tagClosingRE = getTagClosing(tag)
+  return tagClosingRE.test(htmlString)
 }
 function getTagOpening(tag: Tag) {
   const tagOpening = new RegExp(`<${tag}(>| [^>]*>)`, 'i')
   return tagOpening
 }
 function getTagClosing(tag: Tag) {
-  const tagClosing = `</${tag}>`
+  const tagClosing = new RegExp(`</${tag}>`, 'i');
   return tagClosing
 }

--- a/vite-plugin-ssr/node/html/injectAssets/injectHtmlSnippet.ts
+++ b/vite-plugin-ssr/node/html/injectAssets/injectHtmlSnippet.ts
@@ -78,8 +78,6 @@ function getHtmlSnippet(htmlSnippet: string | (() => string)) {
 }
 
 function injectAtOpeningTag(tag: 'head' | 'html' | '!doctype', htmlString: string, htmlSnippet: string): string {
-  assert(tagOpeningExists(tag, htmlString))
-
   const openingTag = getTagOpening(tag)
   const matches = htmlString.match(openingTag)
   assert(matches && matches.length >= 1)
@@ -95,8 +93,6 @@ function injectAtOpeningTag(tag: 'head' | 'html' | '!doctype', htmlString: strin
 }
 
 function injectAtClosingTag(tag: 'head' | 'body' | 'html', htmlString: string, htmlSnippet: string): string {
-  assert(tagClosingExists(tag, htmlString))
-
   const tagClosing = getTagClosing(tag)
   const matches = htmlString.match(tagClosing)
   assert(matches && matches.length >= 1)

--- a/vite-plugin-ssr/node/html/injectAssets/injectHtmlSnippet.ts
+++ b/vite-plugin-ssr/node/html/injectAssets/injectHtmlSnippet.ts
@@ -139,6 +139,9 @@ function createHtmlHeadIfMissing(htmlString: string): string {
 }
 
 type Tag = 'html' | 'head' | 'body' | '!doctype'
+// Pay attention to performance when searching for tags
+// Use the most effective way to test or match tag existence
+// Use tag existence checking with caution as it is costly operation
 function tagOpeningExists(tag: Tag, htmlString: string) {
   const tagOpeningRE = getTagOpening(tag)
   return tagOpeningRE.test(htmlString)

--- a/vite-plugin-ssr/node/html/injectAssets/injectHtmlSnippet.ts
+++ b/vite-plugin-ssr/node/html/injectAssets/injectHtmlSnippet.ts
@@ -152,6 +152,6 @@ function getTagOpening(tag: Tag) {
   return tagOpening
 }
 function getTagClosing(tag: Tag) {
-  const tagClosing = new RegExp(`</${tag}>`, 'i');
+  const tagClosing = new RegExp(`</${tag}>`, 'i')
   return tagClosing
 }


### PR DESCRIPTION
Hello @brillout! Thank you for your awesome work on this plugin. I love it's flexibility and ease of use.

I am building quite a large SSR project around it and seeking the best possible performance. I've noticed, there is a non-negligible framework overhead. So I started profiling the costly functions calls. Surprisingly, all the expensive operations are located in `injectHtmlSnippet.ts`. There was very inefficient `getTagClosing` using `String.includes` and lowercasing all html... I refactored this function using `RegExp` as in `tagClosingExists`. The result is the whole `injectAssetsToStream` operation is approx. 3.5x faster.

BEFORE:
![default](https://user-images.githubusercontent.com/5631971/195864715-0cd57239-9afc-4449-92de-4b45a4c31ccc.png)

AFTER:
![Screenshot_11](https://user-images.githubusercontent.com/5631971/195864861-f7429801-5898-4c3e-80dc-553280fa9473.png)

I have also noticed a lot of `assert()` to heavy check results during runtime. However, those runtime "double" or sometimes "tripple" checks where the regexp has to be evaluated on large HTML multiple times is costly.

I can imagine more performance gains when rewriting `injectAssetsToStream` fewer checks, resulting in fewer regex evaluations and faster execution.

Thanks!