### PR TITLE
chore: ignore git logs during new app scaffolding

### DIFF
--- a/boilerplates/index.js
+++ b/boilerplates/index.js
@@ -180,8 +180,8 @@ function initGitRepo(cwd) {
     return
   }
 
-  execSync('git init', { cwd })
-  execSync('git add .', { cwd })
+  execSync('git init', { cwd, stdio: 'ignore' })
+  execSync('git add .', { cwd, stdio: 'ignore' })
   execSync(
     [
       'git',
@@ -191,7 +191,7 @@ function initGitRepo(cwd) {
       '--no-gpg-sign',
       '--message="boilerplate Vite w/ vite-plugin-ssr"'
     ].join(' '),
-    { cwd }
+    { cwd, stdio: 'ignore' }
   )
 }
 function isGitInstalled() {

--- a/boilerplates/index.js
+++ b/boilerplates/index.js
@@ -180,20 +180,35 @@ function initGitRepo(cwd) {
     return
   }
 
-  execSync('git init', { cwd, stdio: 'ignore' })
-  execSync('git add .', { cwd, stdio: 'ignore' })
-  execSync(
-    [
-      'git',
-      '-c user.name="Romuald Brillout"',
-      '-c user.email="vite-plugin-ssr@brillout.com"',
-      'commit',
-      '--no-gpg-sign',
-      '--message="boilerplate Vite w/ vite-plugin-ssr"'
-    ].join(' '),
-    { cwd, stdio: 'ignore' }
-  )
+  let isInitialized = false
+  try {
+    // Attempt to create a git repository.
+    // We hide standard git-related logs from the user, but
+    // do log information for any process that exits with an error.
+    execSync('git init', { cwd, stdio: 'ignore' })
+    isInitialized = true
+
+    execSync('git add .', { cwd, stdio: 'ignore' })
+    execSync(
+      [
+        'git',
+        '-c user.name="Romuald Brillout"',
+        '-c user.email="vite-plugin-ssr@brillout.com"',
+        'commit',
+        '--no-gpg-sign',
+        '--message="boilerplate Vite w/ vite-plugin-ssr"'
+      ].join(' '),
+      { cwd, stdio: 'ignore' }
+    )
+  } catch (error) {
+    if (isInitialized) {
+      fs.rmSync(path.join(cwd, '.git'), { recursive: true, force: true })
+    }
+    console.warn('\nCould not initialize a git repository.')
+    console.warn(error)
+  }
 }
+
 function isGitInstalled() {
   let stdout
   try {


### PR DESCRIPTION
Previously, running `npm init vite-plugin-ssr@latest` would include a few logs from git that were cluttering the scaffolder's output. This change prevents git from logging to the user's terminal when initializing the new git repository and creating the first commit. 

See #478 for full details. 