### PR TITLE
Improve `_default.page.*` documentation markup

### DIFF
--- a/docs/pages/default-page.page.server.mdx
+++ b/docs/pages/default-page.page.server.mdx
@@ -10,13 +10,14 @@ For example, we usually define a <Link text={<><code>render()</code> hook</>} hr
 
 // This `render()` hook applies to all our pages
 export async function render(pageContext) {
+  const { Page } = pageContext;
   return escapeInject`<!DOCTYPE html>
     <html>
       <head>
         <title>My SSR App</title>
       </head>
       <body>
-        <div id="root">${dangerouslySkipEscape(renderToHtml(pageContext.Page))}</div>
+        <div id="root">${dangerouslySkipEscape(renderToHtml(<Page />))}</div>
       </body>
     </html>`
 }


### PR DESCRIPTION
Hello 👋, I'm not necessarily proposing this exact change but I wanted to make a PR instead of an issue to show I'm happy to do the work.

TLDR: make it clearer how HTML rendering APIs work on the `_default.page.*` doc page.

---

The markup on the `_default.page.*` [documentation](https://vite-plugin-ssr.com/default-page) feels a bit misleading to me.

I'm using React. When I tried to use ReactDOM's `renderToString` function and copy the implementation in the docs I kept getting an empty string instead of markup.

The reason for this is that I was passing `pageContext.Page` instead of `pageContext.Page()` or destructing and instantiating the component like `<Page />`

Ex:

```
// renders empty string
renderToString(pageContext.Page)

// renders markup
renderToString(pageContext.Page())

// renders markup
const {Page} = pageContext
renderToString(<Page />)
```

---

[The example](https://github.com/brillout/vite-plugin-ssr/blob/main/boilerplates/boilerplate-react-ts/renderer/_default.page.server.tsx) is good, but I did not realize that destructing the Page component and instantiating it was necessary for the `renderToString` function.

I don't know what the Vue API for rendering HTML looks like (One reason why this exact change may be unsuitable), but it could be useful to either change the markup in the docs or add a note to the docs explicitly stating that you must instantiate the component to render it to markup.

I realize this is not strictly related to the plugin, but this caused me quite a bit of trouble because I wasn't familiar with the ReactDOM API and I think a change like this would be very simple and would help people like me who are not familiar with the HTML rendering APIs in Vue and React.