### PR TITLE
use jsdoc deprecated

### DIFF
--- a/vite-plugin-ssr/node/renderPage.ts
+++ b/vite-plugin-ssr/node/renderPage.ts
@@ -229,7 +229,7 @@ async function initializePageContext(pageContextInit: { urlOriginal: string }) {
 async function renderPage<
   PageContextAdded extends {},
   PageContextInit extends {
-    /** Outdated, do not use */
+    /** @deprecated do not use */
     url?: string
     /** The URL of the HTTP request */
     urlOriginal?: string
@@ -540,6 +540,7 @@ async function renderStatic404Page(globalContext: GlobalRenderingContext & { _is
 
 type PageContextPublic = {
   urlOriginal: string
+  /** @deprecated */
   url: string // outdated
   urlPathname: string
   urlParsed: PageContextUrls['urlParsed']

--- a/vite-plugin-ssr/shared/addComputedUrlProps.ts
+++ b/vite-plugin-ssr/shared/addComputedUrlProps.ts
@@ -19,17 +19,17 @@ type UrlParsed = {
   searchAll: Record<string, string[]>
   /** The URL search parameterer string, e.g. `?details=yes` of `https://example.com/product/42?details=yes#reviews` */
   searchOriginal: null | string
-  /** Outdated, do not use */
+  /** @deprecated do not use */
   searchString: null | string
   /** The URL hash, e.g. `reviews` of `https://example.com/product/42?details=yes#reviews` */
   hash: string
   /** The URL hash string, e.g. `#reviews` of `https://example.com/product/42?details=yes#reviews` */
   hashOriginal: null | string
-  /** Outdated, do not use */
+  /** @deprecated do not use */
   hashString: null | string
 }
 type PageContextUrls = {
-  /** Outdated. Don't use. */
+  /** @deprecated Don't use. */
   url: string
   /** The URL of the HTTP request */
   urlOriginal: string

--- a/vite-plugin-ssr/shared/types.ts
+++ b/vite-plugin-ssr/shared/types.ts
@@ -9,12 +9,12 @@ export type PageContextBuiltIn<Page = any> = {
   exports: Record<string, unknown>
   /** Same as `pageContext.exports` but cumulative */
   exportsAll: Record<string, { exportValue: unknown }[]>
-  /** Outdated. Don't use. */
+  /** @deprecated Don't use. */
   url: string
   /** The URL of the current page */
   urlOriginal: string
   /** If an error occurs, whether the error is a `404 Page Not Found` or a `500 Internal Server Error`, see https://vite-plugin-ssr.com/error-page */
   is404?: boolean
-  /** Outdated, do not use */
+  /** @deprecated do not use */
   pageExports: Record<string, unknown>
 } & PageContextUrls


### PR DESCRIPTION
Replaced "Outdated" with JSDoc `@deprecated`. IDEs now show deprecation hints inline.

This PR is naive. I simply CMD + F the repo for "Outdated" and replaced "Outdated" with @deprecated. 
   
<img width="644" alt="Screenshot 2022-10-29 at 17 22 56" src="https://user-images.githubusercontent.com/35429197/198839879-19f2ed7b-9e02-4f32-8a7a-30b535ea76ed.png">
