### PR TITLE
changed the order of the e.g.  and added a Number

### DIFF
--- a/docs/pages/routing-precedence.page.server.mdx
+++ b/docs/pages/routing-precedence.page.server.mdx
@@ -21,17 +21,21 @@ Upon conflicts between Filesystem Routing, Route Strings and Route Functions, `v
 1. Route Function, returned high negative `precedence` number (e.g. `-99`)
 
 **Example (4) + (6) + (7)**:
-
 ```js
-// product/item.page.route.js
-export default '/product/@productId'
-```
-```js
+Example 4: 
 // product/list.page.route.js
 export default '/product'
 ```
 
 ```js
+Example 6:
+// product/item.page.route.js
+export default '/product/@productId'
+```
+
+
+```js
+Example 7:
 // product/catch-all.page.route.js
 export default pageContext => {
   if (!pageContext.urlPathname.startsWith('/product/')) return false
@@ -44,19 +48,21 @@ export default pageContext => {
   }
 }
 ```
-
+ 
+ ```
+URL                           MATCHES                                    WINNER
+==================            ===================================        ======
+/product                      product/list.page.route.js      (4)        ⬅️
+                              product/catch-all.page.route.js (7)
+```
+ 
 ```
 URL                           MATCHES                                    WINNER
 ==================            ===================================        ======
 /product/42                   product/item.page.route.js      (6)        ⬅️
                               product/catch-all.page.route.js (7)
 ```
-```
-URL                           MATCHES                                    WINNER
-==================            ===================================        ======
-/product                      product/list.page.route.js      (4)        ⬅️
-                              product/catch-all.page.route.js (7)
-```
+
 ```
 URL                           MATCHES                                    WINNER
 ==================            ===================================        ======

--- a/docs/pages/routing-precedence.page.server.mdx
+++ b/docs/pages/routing-precedence.page.server.mdx
@@ -21,21 +21,16 @@ Upon conflicts between Filesystem Routing, Route Strings and Route Functions, `v
 1. Route Function, returned high negative `precedence` number (e.g. `-99`)
 
 **Example (4) + (6) + (7)**:
+
 ```js
-Example 4: 
 // product/list.page.route.js
 export default '/product'
 ```
-
 ```js
-Example 6:
 // product/item.page.route.js
 export default '/product/@productId'
 ```
-
-
 ```js
-Example 7:
 // product/catch-all.page.route.js
 export default pageContext => {
   if (!pageContext.urlPathname.startsWith('/product/')) return false
@@ -48,21 +43,19 @@ export default pageContext => {
   }
 }
 ```
- 
- ```
-URL                           MATCHES                                    WINNER
-==================            ===================================        ======
-/product                      product/list.page.route.js      (4)        ⬅️
-                              product/catch-all.page.route.js (7)
-```
- 
+
 ```
 URL                           MATCHES                                    WINNER
 ==================            ===================================        ======
 /product/42                   product/item.page.route.js      (6)        ⬅️
                               product/catch-all.page.route.js (7)
 ```
-
+```
+URL                           MATCHES                                    WINNER
+==================            ===================================        ======
+/product                      product/list.page.route.js      (4)        ⬅️
+                              product/catch-all.page.route.js (7)
+```
 ```
 URL                           MATCHES                                    WINNER
 ==================            ===================================        ======


### PR DESCRIPTION
To me, the "routing precedence" appears a bit confusing. 

because the order of the examples is not correct.
you mention " Example (4) + (6) + (7):" 
but I think the order of the following examples is incorrect.   

currently the Example with the number "6" is in the first position and "4" in the second. 

I changed the order and added a number to the examples. 




Examples: 

4 =
 ```js
// product/list.page.route.js
export default '/product'
```

6:
```js
// product/item.page.route.js
export default '/product/@productId'
```
7:
/ product/catch-all.page.route.js
.......