### PR TITLE
remove mention of deprecated feature

### DIFF
--- a/docs/pages/onBeforeRender.page.server.mdx
+++ b/docs/pages/onBeforeRender.page.server.mdx
@@ -41,7 +41,3 @@ Examples:
 If we use <Link href="/clientRouting" noBreadcrumb />,
 we also have the option to define [`onBeforeRender()` in `.page.js`](/onBeforeRender-isomorphic) instead of `.page.server.js`;
 the hook is then called not only in Node.js but also in the browser.
-
-## Multiple `onBeforeRender()`
-
-For a given page, we can define [multiple `onBeforeRender()` hooks](/onBeforeRender-multiple).


### PR DESCRIPTION
Clicking the link opens a page with a big warning "deprecated".