### PR TITLE
fix: pipe original stream asynchronously

### DIFF
--- a/vite-plugin-ssr/node/html/stream.ts
+++ b/vite-plugin-ssr/node/html/stream.ts
@@ -458,7 +458,7 @@ async function manipulateStream<StreamType extends Stream>({
     assert(typeof writableProxy.flush === 'function')
 
     const pipeOriginal = getStreamPipeNode(streamOriginal)
-    pipeOriginal(writableProxy)
+    setTimeout(() => pipeOriginal(writableProxy))
 
     return { streamWrapper: pipeProxy as typeof streamOriginal, streamOperations: { writeChunk, flushStream } }
   }
@@ -536,7 +536,7 @@ async function manipulateStream<StreamType extends Stream>({
     }
 
     const pipeOriginal = getStreamPipeWeb(streamOriginal)
-    pipeOriginal(writableProxy)
+    setTimeout(() => pipeOriginal(writableProxy))
 
     return { streamWrapper: pipeProxy as typeof streamOriginal, streamOperations: { writeChunk, flushStream } }
   }


### PR DESCRIPTION
This PR fixes a minor bug that the streaming not starting when the writable pipe from `render()` wrote the initial chunk synchronously.