### PR TITLE
Typo + grammar clarification

### DIFF
--- a/docs/pages/index/features/Features.tsx
+++ b/docs/pages/index/features/Features.tsx
@@ -165,7 +165,7 @@ function Features() {
           desc: (
             <>
               <p>
-                The source code of <code>vite-plugin-ssr</code> has <b>no known bug</b>, every release is assailed
+                The source code of <code>vite-plugin-ssr</code> has <b>no known bugs</b>, every release is assailed
                 against a heavy suite of <b>automated tests</b>, and it's <b>used in production</b> by many
                 comp&shy;anies.
               </p>

--- a/docs/pages/index/features/Features.tsx
+++ b/docs/pages/index/features/Features.tsx
@@ -261,7 +261,7 @@ function Features() {
               <p>You can preload links for instantaneous page navigation.</p>
               <h3>Fast Cold Starts</h3>
               <p>
-                On the server-side, pages are as well lazy-loaded: adding pages doesn't increase the cold start of your
+                On the server-side, pages are also lazy-loaded: adding pages doesn't increase the cold start of your
                 (serverless) deployment.
               </p>
             </>
@@ -318,7 +318,7 @@ function Features() {
                 Crafted with <b>attention to details</b> and <b>care for simplicity</b>.
               </p>
               <p>
-                <b>Upsteam contributions</b> to Vite and others.
+                <b>Upstream contributions</b> to Vite and others.
               </p>
               <p>
                 GitHub and Discord <b>conversations are welcome</b>.


### PR DESCRIPTION
Upsteam is a typo. The other changes are a little more subjective, can remove them if you think it's unnecessary.