### PR TITLE
Fix typo in meta.page.server.mdx

### DIFF
--- a/docs/pages/meta.page.server.mdx
+++ b/docs/pages/meta.page.server.mdx
@@ -37,7 +37,7 @@ export default {
   // Set <title>
   title: 'My vite-plugin-ssr app',
   // Set <meta name="description" />
-  title: 'This app showcases using vite-plugin-ssr'
+  description: 'This app showcases using vite-plugin-ssr'
 }
 ```
 


### PR DESCRIPTION
Fixes a small typo in `meta.page.server.mdx`.