### PR TITLE
filesystemRoutingRoot: Needs a string but TS asks for a boolean

### DIFF
--- a/vite-plugin-ssr/shared/page-configs/Config.ts
+++ b/vite-plugin-ssr/shared/page-configs/Config.ts
@@ -76,7 +76,7 @@ type Config<Page = unknown> = Partial<{
    *
    * See https://vite-plugin-ssr.com/filesystemRoutingRoot
    */
-  filesystemRoutingRoot: boolean
+  filesystemRoutingRoot: string
 
   /** Page Hook called when pre-rendering starts.
    *


### PR DESCRIPTION
I have this TS code which returns an error, `TS2322: Type 'string' is not assignable to type 'boolean'.`

```
export default {
  filesystemRoutingRoot: "/",
} satisfies Config;
```

Config seems to require `filesystemRoutingRoot` to be a boolean, but if I set it to a boolean, I get this error at runtime:
```
Error: [vite-plugin-ssr@0.4.131][Wrong Usage] /ssg/pages/+config.h.ts > `export default { filesystemRoutingRoot } should be a string
```

Therefore I believe it should be a string.