### PR TITLE
Update `all.page.server.js`, fixed server side route

### DIFF
--- a/examples/vue-router/pages/all.page.server.js
+++ b/examples/vue-router/pages/all.page.server.js
@@ -9,7 +9,7 @@ async function render(pageContext) {
   const { app, router } = createApp({ Page })
 
   // set the router to the desired URL before rendering
-  router.push(pageContext.urlPathname)
+  router.push(pageContext.urlOriginal)
   await router.isReady()
 
   const appHtml = await renderToString(app)


### PR DESCRIPTION
We should use `router.push(pageContext.urlOriginal)` but not `urlPathname`, for pass query and hash to the renderer