### PR TITLE
Fixes "Data Fetching" docs

### DIFF
--- a/docs/pages/data-fetching.page.server.mdx
+++ b/docs/pages/data-fetching.page.server.mdx
@@ -71,8 +71,6 @@ export { render }
 import { hydrateDom, createElement } from 'some-ui-framework'
 
 async function render(pageContext) {
-  // `Page` is also available in the browser
-  const { Page } = pageContext
   // Thanks to `passToClient = ['pageProps']` our `pageContext.pageProps` is
   // available here in the browser.
   const { Page, pageProps } = pageContext


### PR DESCRIPTION
There is duplicate `Page` declarations which results with this error:

![Screenshot 2023-07-20 at 14 15 39](https://github.com/brillout/vite-plugin-ssr/assets/2223680/2a818e07-8701-4879-afe6-8160d2d9d865)

I believe the intent was to showcase the `pageProps` being available, so I removed the first declaration with `Page` and kept the second one.