### PR TITLE
Faster URL Parsing

### DIFF
--- a/vite-plugin-ssr/utils/parseUrl.ts
+++ b/vite-plugin-ssr/utils/parseUrl.ts
@@ -132,31 +132,22 @@ function parseWithNewUrl(urlWithoutHashNorSearch: string, baseServer: string) {
     urlWithoutHashNorSearch = PROTOCOL_FAKE + urlWithoutHashNorSearch.slice(PROTOCOL_TAURI.length)
   }
 
-  let origin: string | null
-  let pathnameResolved: string
-  try {
-    // `new URL(url)` throws an error if `url` doesn't have an origin
-    const urlParsed = new URL(urlWithoutHashNorSearch)
-    origin = urlParsed.origin
-    pathnameResolved = urlParsed.pathname
-  } catch (err) {
-    // `url` has no origin
-    origin = null
-    // In the browser, this is the Base URL of the current URL
-    let base =
-      typeof window !== 'undefined' &&
-      // We need to access safely in case the user sets `window` in Node.js
-      window?.document?.baseURI
-    base = base || 'http://fake.example.org' + baseServer
-    // `new Url()` supports:
-    //  - `url === '/absolute/path'`
-    //  - `url === './relative/path'`
-    //  - `url === '?queryWithoutPath'`
-    //  - `url === '''`
-    // `base` in `new URL(url, base)` is used for resolving relative paths (`new URL()` doesn't remove `base` from `pathname`)
-    const urlParsed = new URL(urlWithoutHashNorSearch, base)
-    pathnameResolved = urlParsed.pathname
-  }
+  // In the browser, this is the Base URL of the current URL
+  let base =
+    typeof window === 'undefined'
+      ? 'http://fake.org' + baseServer
+      : // We need to access safely in case the user sets `window` in Node.js
+        window?.document?.baseURI
+
+  // `new Url()` supports:
+  //  - `url === '/absolute/path'`
+  //  - `url === './relative/path'`
+  //  - `url === '?queryWithoutPath'`
+  //  - `url === '''`
+  // `base` in `new URL(url, base)` is used for resolving relative paths (`new URL()` doesn't remove `base` from `pathname`)
+  const urlParsed = new URL(urlWithoutHashNorSearch, base)
+  let pathnameResolved = urlParsed.pathname
+  let origin = urlWithoutHashNorSearch.startsWith(urlParsed.origin) ? urlParsed.origin : null
 
   if (!pathnameResolved) pathnameResolved = '/'
 

--- a/vite-plugin-ssr/utils/parseUrl.ts
+++ b/vite-plugin-ssr/utils/parseUrl.ts
@@ -133,11 +133,8 @@ function parseWithNewUrl(urlWithoutHashNorSearch: string, baseServer: string) {
   }
 
   // In the browser, this is the Base URL of the current URL
-  let base =
-    typeof window === 'undefined'
-      ? 'http://fake.org' + baseServer
-      : // We need to access safely in case the user sets `window` in Node.js
-        window?.document?.baseURI
+  // Safe access `window?.document?.baseURI` for users who shim `window` in Node.js
+  const base = (typeof window !== 'undefined' && window?.document?.baseURI) || 'http://fake.org' + baseServer
 
   // `new URL(url)` supports:
   //  - `url === '/absolute/path'`

--- a/vite-plugin-ssr/utils/parseUrl.ts
+++ b/vite-plugin-ssr/utils/parseUrl.ts
@@ -139,11 +139,11 @@ function parseWithNewUrl(urlWithoutHashNorSearch: string, baseServer: string) {
       : // We need to access safely in case the user sets `window` in Node.js
         window?.document?.baseURI
 
-  // `new Url()` supports:
+  // `new URL(url)` supports:
   //  - `url === '/absolute/path'`
   //  - `url === './relative/path'`
   //  - `url === '?queryWithoutPath'`
-  //  - `url === '''`
+  //  - `url === ''`
   // `base` in `new URL(url, base)` is used for resolving relative paths (`new URL()` doesn't remove `base` from `pathname`)
   const urlParsed = new URL(urlWithoutHashNorSearch, base)
   let pathnameResolved = urlParsed.pathname


### PR DESCRIPTION
Improves https://github.com/brillout/vite-plugin-ssr/issues/1115 by removing try/catch to avoid error handling overhead when pathname is relative and no `base` is passed to URL constructor.

Benchmark using the `npm create vite-plugin-ssr starter` repo on the index page. Used [bombardier](https://github.com/codesenberg/bombardier) on Macbook with M1 Pro.

before:
```
Statistics        Avg      Stdev        Max
  Reqs/sec      1312.95     223.14    3744.83
  Latency       94.75ms    17.55ms   244.31ms
```
after:
```
Statistics        Avg      Stdev        Max
  Reqs/sec      2269.03     439.82    6707.62
  Latency       54.98ms    12.65ms   190.80ms
```
